### PR TITLE
Proposed fix to issue #35 & #36 (revised)

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/mecanum/SampleMecanumDriveBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/mecanum/SampleMecanumDriveBase.java
@@ -92,7 +92,7 @@ public abstract class SampleMecanumDriveBase extends MecanumDrive {
                 constraints.maxAngAccel,
                 constraints.maxAngJerk
         );
-        turnController.setTargetPosition(angle);
+        turnController.setTargetPosition(heading + angle);
         turnStart = clock.seconds();
         mode = Mode.TURN;
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/mecanum/SampleMecanumDriveBase.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/mecanum/SampleMecanumDriveBase.java
@@ -92,6 +92,7 @@ public abstract class SampleMecanumDriveBase extends MecanumDrive {
                 constraints.maxAngAccel,
                 constraints.maxAngJerk
         );
+        turnController.setTargetPosition(angle);
         turnStart = clock.seconds();
         mode = Mode.TURN;
     }


### PR DESCRIPTION
## Problem
The target position is not set to `SampleMecanumDriveBase`'s `turnController`. It is always 0.0, causing incorrect heading error be calculated when the drive is in TURN mode.
## Proposed solution
We find that adding:

```java
turnController.setTargetPosition(heading + angle);
```

`turn(double angle)` addresses the problem.

## Related:
* Behavior
[#35 https://github.com/acmerobotics/road-runner-quickstart/issues/35](https://github.com/acmerobotics/road-runner-quickstart/issues/35) 
* Cause
[#36 Incorrect error calculation by `turnController`]( https://github.com/acmerobotics/road-runner-quickstart/issues/36)
