### PR TITLE
Fix link to quickstart documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ For more detailed instructions on getting Road Runner setup in your own project,
 
 ## Documentation
 
-Check out the new [online quickstart documentation](https://acme-robotics.gitbook.io/road-runner/quickstart).
+Check out the new [online quickstart documentation](https://acme-robotics.gitbook.io/road-runner/quickstart/introduction).


### PR DESCRIPTION
Before issuing a pull request, please see the contributing page.
