### PR TITLE
Change SplineTest to return to original pose

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/SplineTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/SplineTest.java
@@ -30,7 +30,7 @@ public class SplineTest extends LinearOpMode {
         sleep(2000);
 
         drive.followTrajectory(
-                drive.trajectoryBuilder(new Pose2d(30, 30, Math.toRadians(180)), true)
+                drive.trajectoryBuilder(new Pose2d(30, 30, Math.toRadians(0)), true)
                         .splineTo(new Vector2d(0, 0), Math.toRadians(180))
                         .build()
         );

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/SplineTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/SplineTest.java
@@ -30,7 +30,7 @@ public class SplineTest extends LinearOpMode {
         sleep(2000);
 
         drive.followTrajectory(
-                drive.trajectoryBuilder(new Pose2d(30, 30, Math.toRadians(0)), true)
+                drive.trajectoryBuilder(traj.end(), true)
                         .splineTo(new Vector2d(0, 0), Math.toRadians(180))
                         .build()
         );


### PR DESCRIPTION
We used 0.4.6 last year, and after upgrading to 0.5.1 it seems that we have to make this change to SplineTest in order to make the robot travel in the same way as we remember before.