### PR TITLE
Draw pose in dashboard during IDLE and TURN modes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -219,6 +219,10 @@ public class SampleMecanumDrive extends MecanumDrive {
         switch (mode) {
             case IDLE:
                 // do nothing
+
+                fieldOverlay.setStrokeWidth(1);
+                fieldOverlay.setStroke("#DF3003");
+                DashboardUtil.drawRobot(fieldOverlay, currentPose);
                 break;
             case TURN: {
                 double t = clock.seconds() - turnStart;
@@ -241,6 +245,10 @@ public class SampleMecanumDrive extends MecanumDrive {
                     mode = Mode.IDLE;
                     setDriveSignal(new DriveSignal());
                 }
+
+                fieldOverlay.setStrokeWidth(1);
+                fieldOverlay.setStroke("#47B04B");
+                DashboardUtil.drawRobot(fieldOverlay, currentPose);
 
                 break;
             }


### PR DESCRIPTION
IDLE and TURN each are drawn in different colors: #DF3003 (red) for IDLE and #47B04B (green) for TURN. Both colors are sampled from the RGB in the screenshot in the ftc-dashboard README.