### PR TITLE
Replace multiple telemetry with TelemetryPacket for faster updates

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -6,6 +6,7 @@ import com.acmerobotics.dashboard.config.ValueProvider;
 import com.acmerobotics.dashboard.config.variable.BasicVariable;
 import com.acmerobotics.dashboard.config.variable.CustomVariable;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
 import com.acmerobotics.roadrunner.control.PIDCoefficients;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.acmerobotics.roadrunner.profile.MotionProfile;
@@ -168,13 +169,15 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
 
             List<Double> velocities = drive.getWheelVelocities();
 
+            TelemetryPacket packet = new TelemetryPacket();
+
             // update telemetry
-            telemetry.addData("targetVelocity", motionState.getV());
+            packet.put("targetVelocity", motionState.getV());
             for (int i = 0; i < velocities.size(); i++) {
-                telemetry.addData("velocity" + i, velocities.get(i));
-                telemetry.addData("error" + i, motionState.getV() - velocities.get(i));
+                packet.put("velocity" + i, velocities.get(i));
+                packet.put("error" + i, motionState.getV() - velocities.get(i));
             }
-            telemetry.update();
+            dashboard.sendTelemetryPacket(packet);
         }
 
         removePidVariable();


### PR DESCRIPTION
Replace the graphing functions with telemetry packets instead of the multiple telemetry. Telemetry packets are fired at a much higher frequency by default resulting in a better graph resolution. There isn't much of a benefit to printing the graphing data to the RC telemetry anyways. 