### PR TITLE
Add encoder wrapper to correct high CPS integer overflow

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/StandardTrackingWheelLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/StandardTrackingWheelLocalizer.java
@@ -67,10 +67,13 @@ public class StandardTrackingWheelLocalizer extends ThreeTrackingWheelLocalizer 
     @NonNull
     @Override
     public List<Double> getWheelVelocities() {
+        // TODO: If your encoder velocity can exceed 32767 counts / second, change Encoder.getRawVelocity() to
+        // Encoder.getCorrectedVelocity() to enable a compensation method
+
         return Arrays.asList(
-                encoderTicksToInches(leftEncoder.getVelocity()),
-                encoderTicksToInches(rightEncoder.getVelocity()),
-                encoderTicksToInches(frontEncoder.getVelocity())
+                encoderTicksToInches(leftEncoder.getRawVelocity()),
+                encoderTicksToInches(rightEncoder.getRawVelocity()),
+                encoderTicksToInches(frontEncoder.getRawVelocity())
         );
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/StandardTrackingWheelLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/StandardTrackingWheelLocalizer.java
@@ -5,9 +5,9 @@ import androidx.annotation.NonNull;
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.acmerobotics.roadrunner.localization.ThreeTrackingWheelLocalizer;
-import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.HardwareMap;
+import org.firstinspires.ftc.teamcode.util.Encoder;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +34,7 @@ public class StandardTrackingWheelLocalizer extends ThreeTrackingWheelLocalizer 
     public static double LATERAL_DISTANCE = 10; // in; distance between the left and right wheels
     public static double FORWARD_OFFSET = 4; // in; offset of the lateral wheel
 
-    private DcMotorEx leftEncoder, rightEncoder, frontEncoder;
+    private Encoder leftEncoder, rightEncoder, frontEncoder;
 
     public StandardTrackingWheelLocalizer(HardwareMap hardwareMap) {
         super(Arrays.asList(
@@ -43,9 +43,11 @@ public class StandardTrackingWheelLocalizer extends ThreeTrackingWheelLocalizer 
                 new Pose2d(FORWARD_OFFSET, 0, Math.toRadians(90)) // front
         ));
 
-        leftEncoder = hardwareMap.get(DcMotorEx.class, "leftEncoder");
-        rightEncoder = hardwareMap.get(DcMotorEx.class, "rightEncoder");
-        frontEncoder = hardwareMap.get(DcMotorEx.class, "frontEncoder");
+        leftEncoder = new Encoder(hardwareMap.get(DcMotorEx.class, "leftEncoder"));
+        rightEncoder = new Encoder(hardwareMap.get(DcMotorEx.class, "rightEncoder"));
+        frontEncoder = new Encoder(hardwareMap.get(DcMotorEx.class, "frontEncoder"));
+
+        // TODO: reverse any encoders using Encoder.setDirection(Encoder.Direction.REVERSE)
     }
 
     public static double encoderTicksToInches(double ticks) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/StandardTrackingWheelLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/StandardTrackingWheelLocalizer.java
@@ -67,8 +67,9 @@ public class StandardTrackingWheelLocalizer extends ThreeTrackingWheelLocalizer 
     @NonNull
     @Override
     public List<Double> getWheelVelocities() {
-        // TODO: If your encoder velocity can exceed 32767 counts / second, change Encoder.getRawVelocity() to
-        // Encoder.getCorrectedVelocity() to enable a compensation method
+        // TODO: If your encoder velocity can exceed 32767 counts / second (such as the REV Through Bore and other
+        //  competing magnetic encoders), change Encoder.getRawVelocity() to Encoder.getCorrectedVelocity() to enable a
+        //  compensation method
 
         return Arrays.asList(
                 encoderTicksToInches(leftEncoder.getRawVelocity()),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
@@ -8,9 +8,9 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
  * slot's motor direction
  */
 public class Encoder {
-    public static int CPS_STEP = 0x10000;
+    private final static int CPS_STEP = 0x10000;
 
-    public static double inverseOverflow(double input, double estimate) {
+    private static double inverseOverflow(double input, double estimate) {
         double real = input;
         while (Math.abs(estimate - real) > CPS_STEP / 2.0) {
             real += Math.signum(estimate - real) * CPS_STEP;
@@ -82,7 +82,12 @@ public class Encoder {
         return currentPosition;
     }
 
-    public double getVelocity() {
+    public double getRawVelocity() {
+        int multiplier = direction.getMultiplier();
+        return motor.getVelocity() * multiplier;
+    }
+
+    public double getCorrectedVelocity() {
         int multiplier = direction.getMultiplier();
         double rawVelocity = motor.getVelocity() * multiplier;
         return inverseOverflow(rawVelocity, velocityEstimate);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
@@ -1,0 +1,90 @@
+package org.firstinspires.ftc.teamcode.util;
+
+import com.acmerobotics.roadrunner.util.NanoClock;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+
+/**
+ * Wraps a motor instance to provide corrected velocity counts and allow reversing without changing the corresponding
+ * slot's motor direction
+ */
+public class Encoder {
+    public static int CPS_STEP = 0x10000;
+
+    public static double inverseOverflow(double input, double estimate) {
+        double real = input;
+        while (Math.abs(estimate - real) > CPS_STEP / 2.0) {
+            real += Math.signum(estimate - real) * CPS_STEP;
+        }
+        return real;
+    }
+
+    public enum Direction {
+        FORWARD(1),
+        REVERSE(-1);
+
+        private int multiplier;
+
+        Direction(int multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        public int getMultiplier() {
+            return multiplier;
+        }
+    }
+
+    private DcMotorEx motor;
+    private NanoClock clock;
+
+    private Direction direction;
+
+    private int lastPosition;
+    private double velocityEstimate;
+    private double lastUpdateTime;
+
+    public Encoder(DcMotorEx motor, NanoClock clock) {
+        this.motor = motor;
+        this.clock = clock;
+
+        this.direction = Direction.FORWARD;
+
+        this.lastPosition = 0;
+        this.velocityEstimate = 0.0;
+        this.lastUpdateTime = clock.seconds();
+    }
+
+    public Encoder(DcMotorEx motor) {
+        this(motor, NanoClock.system());
+    }
+
+    public Direction getDirection() {
+        return direction;
+    }
+
+    /**
+     * Allows you to set the direction of the counts and velocity without modifying the motor's direction state
+     * @param direction either reverse or forward depending on if encoder counts should be negated
+     */
+    public void setDirection(Direction direction) {
+        this.direction = direction;
+    }
+
+    public int getCurrentPosition() {
+        int multiplier = direction.getMultiplier();
+        int currentPosition = motor.getCurrentPosition() * multiplier;
+        if (currentPosition != lastPosition) {
+            double currentTime = clock.seconds();
+            double dt = currentTime - lastUpdateTime;
+            velocityEstimate = (currentPosition - lastPosition) / dt;
+            lastPosition = currentPosition;
+            lastUpdateTime = currentTime;
+        }
+        return currentPosition;
+    }
+
+    public double getVelocity() {
+        int multiplier = direction.getMultiplier();
+        double rawVelocity = motor.getVelocity() * multiplier;
+        return inverseOverflow(rawVelocity, velocityEstimate);
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
@@ -88,8 +88,6 @@ public class Encoder {
     }
 
     public double getCorrectedVelocity() {
-        int multiplier = direction.getMultiplier();
-        double rawVelocity = motor.getVelocity() * multiplier;
-        return inverseOverflow(rawVelocity, velocityEstimate);
+        return inverseOverflow(getRawVelocity(), velocityEstimate);
     }
 }


### PR DESCRIPTION
The `Encoder` wrapper provides a system to correct velocity integer overflows using a numerical velocity estimate and the raw velocity counts. This wrapper also makes reversing encoders easier without affecting the underlying motor if the ports are shared.