### PR TITLE
Set drive mode to RUN_WITHOUT_ENCODER and remove MutlipleTelemetry in LocalizationTest

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
@@ -1,11 +1,10 @@
 package org.firstinspires.ftc.teamcode.drive.opmode;
 
-import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.config.Config;
-import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.hardware.DcMotor;
 
 import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
 
@@ -25,9 +24,9 @@ public class LocalizationTest extends LinearOpMode {
 
     @Override
     public void runOpMode() throws InterruptedException {
-        telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
-
         SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
+
+        drive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
 
         waitForStart();
 


### PR DESCRIPTION
- Remove `MultipleTelemetry` in `LocalizationTest` as the opmode's telemetry conflicts with `SampleMecanumDrive`'s telemetry packets causing FTC Dashboard to flicker
- Set drive mode to `RUN_WITHOUT_ENCODER` as it provides for a better teleop experience. `RUN_WITH_ENCODER` is a little laggy, especially if you run `LocalizationTest` with untuned gains.