### PR TITLE
Improved drive velocity tuner

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
@@ -36,6 +36,12 @@ public class DriveConstants {
     public static final boolean RUN_USING_ENCODER = true;
     public static final PIDCoefficients MOTOR_VELO_PID = null;
 
+    public static double kP = 35;
+    public static double kI = 0;
+    public static double kD = 15;
+
+    public static final PIDCoefficients MOTOR_VELO_PID = new PIDCoefficients(kP, kI, kD);
+
     /*
      * These are physical constants that can be determined from your robot (including the track
      * width; it will be tune empirically later although a rough estimate is important). Users are

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
@@ -31,10 +31,9 @@ public class DriveConstants {
      *
      * If using the built-in motor velocity PID, update
      * MOTOR_VELO_PID with the tuned coefficients from DriveVelocityPIDTuner.
-     * Set the value of MOTOR_VELO_PID to `new PIDCoefficients(kP, kI, kD);`
      */
     public static final boolean RUN_USING_ENCODER = true;
-    public static PIDCoefficients MOTOR_VELO_PID = null;
+    public static PIDCoefficients MOTOR_VELO_PID = new PIDCoefficients(0, 0, 0);
 
     /*
      * These are physical constants that can be determined from your robot (including the track

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
@@ -34,12 +34,7 @@ public class DriveConstants {
      * Set the value of MOTOR_VELO_PID to `new PIDCoefficients(kP, kI, kD);`
      */
     public static final boolean RUN_USING_ENCODER = true;
-
-    public static double kP = 0;
-    public static double kI = 0;
-    public static double kD = 0;
-
-    public static final PIDCoefficients MOTOR_VELO_PID = new PIDCoefficients(kP, kI, kD);
+    public static PIDCoefficients MOTOR_VELO_PID = null;
 
     /*
      * These are physical constants that can be determined from your robot (including the track

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
@@ -34,11 +34,10 @@ public class DriveConstants {
      * Set the value of MOTOR_VELO_PID to `new PIDCoefficients(kP, kI, kD);`
      */
     public static final boolean RUN_USING_ENCODER = true;
-    public static final PIDCoefficients MOTOR_VELO_PID = null;
 
-    public static double kP = 35;
+    public static double kP = 0;
     public static double kI = 0;
-    public static double kD = 15;
+    public static double kD = 0;
 
     public static final PIDCoefficients MOTOR_VELO_PID = new PIDCoefficients(kP, kI, kD);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -325,13 +325,23 @@ public class SampleMecanumDrive extends MecanumDrive {
     }
 
     public void setWeightedDrivePower(Pose2d drivePower) {
-        setDrivePower(
-                new Pose2d(
-                        VX_WEIGHT * drivePower.getX(),
-                        VY_WEIGHT * drivePower.getY(),
-                        OMEGA_WEIGHT * drivePower.getHeading()
-                )
-        );
+        Pose2d vel = drivePower;
+
+        if (Math.abs(drivePower.getX()) + Math.abs(drivePower.getY())
+                + Math.abs(drivePower.getHeading()) > 1) {
+            // re-normalize the powers according to the weights
+            double denom = VX_WEIGHT * Math.abs(drivePower.getX())
+                    + VY_WEIGHT * Math.abs(drivePower.getY())
+                    + OMEGA_WEIGHT * Math.abs(drivePower.getHeading());
+
+            vel = new Pose2d(
+                    VX_WEIGHT * drivePower.getX(),
+                    VY_WEIGHT * drivePower.getY(),
+                    OMEGA_WEIGHT * drivePower.getHeading()
+            ).div(denom);
+        }
+
+        setDrivePower(vel);
     }
 
     @NonNull

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -56,6 +56,10 @@ public class SampleMecanumDrive extends MecanumDrive {
 
     public static double LATERAL_MULTIPLIER = 1;
 
+    public static double VX_WEIGHT = 1;
+    public static double VY_WEIGHT = 1;
+    public static double OMEGA_WEIGHT = 1;
+
     public enum Mode {
         IDLE,
         TURN,
@@ -320,6 +324,16 @@ public class SampleMecanumDrive extends MecanumDrive {
         }
     }
 
+    public void setWeightedDrivePower(Pose2d drivePower) {
+        setDrivePower(
+                new Pose2d(
+                        VX_WEIGHT * drivePower.getX(),
+                        VY_WEIGHT * drivePower.getY(),
+                        OMEGA_WEIGHT * drivePower.getHeading()
+                )
+        );
+    }
+
     @NonNull
     @Override
     public List<Double> getWheelPositions() {
@@ -330,6 +344,7 @@ public class SampleMecanumDrive extends MecanumDrive {
         return wheelPositions;
     }
 
+    @Override
     public List<Double> getWheelVelocities() {
         List<Double> wheelVelocities = new ArrayList<>();
         for (DcMotorEx motor : motors) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
@@ -55,6 +55,9 @@ public class SampleTankDrive extends TankDrive {
     public static PIDCoefficients CROSS_TRACK_PID = new PIDCoefficients(0, 0, 0);
     public static PIDCoefficients HEADING_PID = new PIDCoefficients(0, 0, 0);
 
+    public static double VX_WEIGHT = 1;
+    public static double VY_WEIGHT = 1;
+    public static double OMEGA_WEIGHT = 1;
 
     public enum Mode {
         IDLE,
@@ -308,6 +311,16 @@ public class SampleTankDrive extends TankDrive {
                     coefficients.kP, coefficients.kI, coefficients.kD, getMotorVelocityF()
             ));
         }
+    }
+
+    public void setWeightedDrivePower(Pose2d drivePower) {
+        setDrivePower(
+                new Pose2d(
+                        VX_WEIGHT * drivePower.getX(),
+                        VY_WEIGHT * drivePower.getY(),
+                        OMEGA_WEIGHT * drivePower.getHeading()
+                )
+        );
     }
 
     @NonNull

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
@@ -314,13 +314,23 @@ public class SampleTankDrive extends TankDrive {
     }
 
     public void setWeightedDrivePower(Pose2d drivePower) {
-        setDrivePower(
-                new Pose2d(
-                        VX_WEIGHT * drivePower.getX(),
-                        VY_WEIGHT * drivePower.getY(),
-                        OMEGA_WEIGHT * drivePower.getHeading()
-                )
-        );
+        Pose2d vel = drivePower;
+
+        if (Math.abs(drivePower.getX()) + Math.abs(drivePower.getY())
+                + Math.abs(drivePower.getHeading()) > 1) {
+            // re-normalize the powers according to the weights
+            double denom = VX_WEIGHT * Math.abs(drivePower.getX())
+                    + VY_WEIGHT * Math.abs(drivePower.getY())
+                    + OMEGA_WEIGHT * Math.abs(drivePower.getHeading());
+
+            vel = new Pose2d(
+                    VX_WEIGHT * drivePower.getX(),
+                    VY_WEIGHT * drivePower.getY(),
+                    OMEGA_WEIGHT * drivePower.getHeading()
+            ).div(denom);
+        }
+
+        setDrivePower(vel);
     }
 
     @NonNull

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -180,6 +180,7 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
                 case TUNING_MODE:
                     if(gamepad1.x) {
                         mode = Mode.DRIVER_MODE;
+                        drive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
                     }
 
                     // calculate and set the motor power
@@ -207,6 +208,8 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
                     break;
                 case DRIVER_MODE:
                     if(gamepad1.a) {
+                        drive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+
                         mode = Mode.TUNING_MODE;
                         movingForwards = true;
                         activeProfile = generateProfile(movingForwards);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -3,7 +3,6 @@ package org.firstinspires.ftc.teamcode.drive.opmode;
 import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.config.Config;
 import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
-import com.acmerobotics.roadrunner.control.PIDCoefficients;
 import com.acmerobotics.roadrunner.geometry.Pose2d;
 import com.acmerobotics.roadrunner.profile.MotionProfile;
 import com.acmerobotics.roadrunner.profile.MotionProfileGenerator;
@@ -19,6 +18,7 @@ import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
 
 import java.util.List;
 
+import static org.firstinspires.ftc.teamcode.drive.DriveConstants.MOTOR_VELO_PID;
 import static org.firstinspires.ftc.teamcode.drive.DriveConstants.RUN_USING_ENCODER;
 import static org.firstinspires.ftc.teamcode.drive.DriveConstants.kV;
 
@@ -64,9 +64,9 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
 
     private Mode mode;
 
-    private double lastKp = DriveConstants.kP;
-    private double lastKi = DriveConstants.kI;
-    private double lastKd = DriveConstants.kD;
+    private double lastKp = MOTOR_VELO_PID.kP;
+    private double lastKi = MOTOR_VELO_PID.kI;
+    private double lastKd = MOTOR_VELO_PID.kD;
 
     private static MotionProfile generateProfile(boolean movingForward) {
         MotionState start = new MotionState(movingForward ? 0 : DISTANCE, 0, 0, 0);
@@ -90,8 +90,7 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
 
         mode = Mode.TUNING_MODE;
 
-        drive.setPIDCoefficients(DcMotor.RunMode.RUN_USING_ENCODER,
-                new PIDCoefficients(DriveConstants.kP, DriveConstants.kI, DriveConstants.kD));
+        drive.setPIDCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID);
 
         NanoClock clock = NanoClock.system();
 
@@ -176,14 +175,13 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
                     break;
             }
 
-            if (lastKp != DriveConstants.kP || lastKd != DriveConstants.kD
-                    || lastKi != DriveConstants.kI) {
-                drive.setPIDCoefficients(DcMotor.RunMode.RUN_USING_ENCODER,
-                        new PIDCoefficients(DriveConstants.kP, DriveConstants.kI, DriveConstants.kD));
+            if (lastKp != MOTOR_VELO_PID.kP || lastKd != MOTOR_VELO_PID.kD
+                    || lastKi != MOTOR_VELO_PID.kI) {
+                drive.setPIDCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID);
 
-                lastKp = DriveConstants.kP;
-                lastKi = DriveConstants.kI;
-                lastKd = DriveConstants.kD;
+                lastKp = MOTOR_VELO_PID.kP;
+                lastKi = MOTOR_VELO_PID.kI;
+                lastKd = MOTOR_VELO_PID.kD;
             }
 
             telemetry.update();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -153,25 +153,13 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
                         profileStart = clock.seconds();
                     }
 
-                    Pose2d baseVel = new Pose2d(
-                            -gamepad1.left_stick_y,
-                            -gamepad1.left_stick_x,
-                            -gamepad1.right_stick_x
+                    drive.setWeightedDrivePower(
+                            new Pose2d(
+                                    -gamepad1.left_stick_y,
+                                    -gamepad1.left_stick_x,
+                                    -gamepad1.right_stick_x
+                            )
                     );
-
-                    Pose2d vel;
-                    if (Math.abs(baseVel.getX()) + Math.abs(baseVel.getY())
-                            + Math.abs(baseVel.getHeading()) > 1) {
-                        // re-normalize the powers according to the weights
-                        double denom = Math.abs(baseVel.getX())
-                                + Math.abs(baseVel.getY())
-                                + Math.abs(baseVel.getHeading());
-                        vel = baseVel.div(denom);
-                    } else {
-                        vel = baseVel;
-                    }
-
-                    drive.setWeightedDrivePower(vel);
                     break;
             }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -113,7 +113,7 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
 
 
         while (!isStopRequested()) {
-            telemetry.addData("Mode", mode);
+            telemetry.addData("mode", mode);
 
             switch (mode) {
                 case TUNING_MODE:

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -53,10 +53,6 @@ import static org.firstinspires.ftc.teamcode.drive.DriveConstants.kV;
 public class DriveVelocityPIDTuner extends LinearOpMode {
     public static double DISTANCE = 72; // in
 
-    public static double VX_WEIGHT = 1;
-    public static double VY_WEIGHT = 1;
-    public static double OMEGA_WEIGHT = 1;
-
     private FtcDashboard dashboard = FtcDashboard.getInstance();
 
     private SampleMecanumDrive drive;
@@ -168,19 +164,15 @@ public class DriveVelocityPIDTuner extends LinearOpMode {
                     if (Math.abs(baseVel.getX()) + Math.abs(baseVel.getY())
                             + Math.abs(baseVel.getHeading()) > 1) {
                         // re-normalize the powers according to the weights
-                        double denom = VX_WEIGHT * Math.abs(baseVel.getX())
-                                + VY_WEIGHT * Math.abs(baseVel.getY())
-                                + OMEGA_WEIGHT * Math.abs(baseVel.getHeading());
-                        vel = new Pose2d(
-                                VX_WEIGHT * baseVel.getX(),
-                                VY_WEIGHT * baseVel.getY(),
-                                OMEGA_WEIGHT * baseVel.getHeading()
-                        ).div(denom);
+                        double denom = Math.abs(baseVel.getX())
+                                + Math.abs(baseVel.getY())
+                                + Math.abs(baseVel.getHeading());
+                        vel = baseVel.div(denom);
                     } else {
                         vel = baseVel;
                     }
 
-                    drive.setDrivePower(vel);
+                    drive.setWeightedDrivePower(vel);
                     break;
             }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/DriveVelocityPIDTuner.java
@@ -41,6 +41,12 @@ import static org.firstinspires.ftc.teamcode.drive.DriveConstants.kV;
  *    mitigate oscillations.
  * 2. Add kI (or adjust kF) until the steady state/constant velocity plateaus are reached.
  * 3. Back off kP and kD a little until the response is less oscillatory (but without lag).
+ *
+ * Pressing X (on the Xbox and Logitech F310 gamepads, square on the PS4 Dualshock gamepad) will
+ * pause the tuning process and enter driver override, allowing the user to reset the position of
+ * the bot in the event that it drifts off the path.
+ * Pressing A (on the Xbox and Logitech F310 gamepads, X on the PS4 Dualshock gamepad) will cede
+ * control back to the tuning process.
  */
 @Config
 @Autonomous(group = "drive")

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
@@ -19,10 +19,6 @@ import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
 @Config
 @TeleOp(group = "drive")
 public class LocalizationTest extends LinearOpMode {
-    public static double VX_WEIGHT = 1;
-    public static double VY_WEIGHT = 1;
-    public static double OMEGA_WEIGHT = 1;
-
     @Override
     public void runOpMode() throws InterruptedException {
         telemetry = new MultipleTelemetry(telemetry, FtcDashboard.getInstance().getTelemetry());
@@ -41,19 +37,15 @@ public class LocalizationTest extends LinearOpMode {
             Pose2d vel;
             if (Math.abs(baseVel.getX()) + Math.abs(baseVel.getY()) + Math.abs(baseVel.getHeading()) > 1) {
                 // re-normalize the powers according to the weights
-                double denom = VX_WEIGHT * Math.abs(baseVel.getX())
-                    + VY_WEIGHT * Math.abs(baseVel.getY())
-                    + OMEGA_WEIGHT * Math.abs(baseVel.getHeading());
-                vel = new Pose2d(
-                    VX_WEIGHT * baseVel.getX(),
-                    VY_WEIGHT * baseVel.getY(),
-                    OMEGA_WEIGHT * baseVel.getHeading()
-                ).div(denom);
+                double denom = Math.abs(baseVel.getX())
+                        + Math.abs(baseVel.getY())
+                        + Math.abs(baseVel.getHeading());
+                vel = baseVel.div(denom);
             } else {
                 vel = baseVel;
             }
 
-            drive.setDrivePower(vel);
+            drive.setWeightedDrivePower(vel);
 
             drive.update();
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/LocalizationTest.java
@@ -28,24 +28,13 @@ public class LocalizationTest extends LinearOpMode {
         waitForStart();
 
         while (!isStopRequested()) {
-            Pose2d baseVel = new Pose2d(
-                    -gamepad1.left_stick_y,
-                    -gamepad1.left_stick_x,
-                    -gamepad1.right_stick_x
+            drive.setWeightedDrivePower(
+                    new Pose2d(
+                            -gamepad1.left_stick_y,
+                            -gamepad1.left_stick_x,
+                            -gamepad1.right_stick_x
+                    )
             );
-
-            Pose2d vel;
-            if (Math.abs(baseVel.getX()) + Math.abs(baseVel.getY()) + Math.abs(baseVel.getHeading()) > 1) {
-                // re-normalize the powers according to the weights
-                double denom = Math.abs(baseVel.getX())
-                        + Math.abs(baseVel.getY())
-                        + Math.abs(baseVel.getHeading());
-                vel = baseVel.div(denom);
-            } else {
-                vel = baseVel;
-            }
-
-            drive.setWeightedDrivePower(vel);
 
             drive.update();
 


### PR DESCRIPTION
Add convenience features to the `DriveVelocityTuner`
- Press X (on the xbox gamepads, square on the PS4) to pause the tuning and enter driver control (implementation copy/pasted from `LocalizationTest`)
- Press A (on the xbox gamepads, x on the PS4) to cede control back to the tuner
  - Allows for the user to reset their bot position when it drifts off the path
- Make PID gains persistent
  - Make the velo PID gains static fields in `DriveConstants.java`
  - Remove `CustomVariable` in `DriveVelocityTuner`
  - Make `DriveVelocityTuner` watch for changes in the Velo PID gains from `DriveConstants.java`
  - This offers two advantages (imho):
    - The previous behavior—where the Velo PID gains wouldn't show until init—was slightly confusing. Now that the gains are static fields, they show up on app start.
    - The gains don't disappear upon stopping the opmode so you're able to record them (!!!)