### PR TITLE
Add noise reduction to the Encoder velocity compensation method

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
@@ -12,10 +12,13 @@ public class Encoder {
     private final static int CPS_STEP = 0x10000;
 
     private static double inverseOverflow(double input, double estimate) {
-        double real = input;
-        while (Math.abs(estimate - real) > CPS_STEP / 2.0) {
-            real += Math.signum(estimate - real) * CPS_STEP;
-        }
+        // convert to uint16
+        int real = (int) input & 0xffff;
+        // initial, modulo-based correction: it can recover the remainder of 5 of the upper 16 bits
+        // because the velocity is always a multiple of 20 cps due to Expansion Hub's 50ms measurement window
+        real += ((real % 20) / 4) * CPS_STEP;
+        // estimate-based correction: it finds the nearest multiple of 5 to correct the upper bits by
+        real += Math.round((estimate - real) / (5 * CPS_STEP)) * 5 * CPS_STEP;
         return real;
     }
 
@@ -40,7 +43,8 @@ public class Encoder {
     private Direction direction;
 
     private int lastPosition;
-    private double velocityEstimate;
+    private int velocityEstimateIdx;
+    private double[] velocityEstimates;
     private double lastUpdateTime;
 
     public Encoder(DcMotorEx motor, NanoClock clock) {
@@ -50,7 +54,7 @@ public class Encoder {
         this.direction = Direction.FORWARD;
 
         this.lastPosition = 0;
-        this.velocityEstimate = 0.0;
+        this.velocityEstimates = new double[3];
         this.lastUpdateTime = clock.seconds();
     }
 
@@ -74,25 +78,48 @@ public class Encoder {
         this.direction = direction;
     }
 
+    /**
+     * Gets the position from the underlying motor and adjusts for the set direction.
+     * Additionally, this method updates the velocity estimates used for compensated velocity
+     *
+     * @return encoder position
+     */
     public int getCurrentPosition() {
         int multiplier = getMultiplier();
         int currentPosition = motor.getCurrentPosition() * multiplier;
         if (currentPosition != lastPosition) {
             double currentTime = clock.seconds();
             double dt = currentTime - lastUpdateTime;
-            velocityEstimate = (currentPosition - lastPosition) / dt;
+            velocityEstimates[velocityEstimateIdx] = (currentPosition - lastPosition) / dt;
+            velocityEstimateIdx = (velocityEstimateIdx + 1) % 3;
             lastPosition = currentPosition;
             lastUpdateTime = currentTime;
         }
         return currentPosition;
     }
 
+    /**
+     * Gets the velocity directly from the underlying motor and compensates for the direction
+     * See {@link #getCorrectedVelocity} for high (>2^15) counts per second velocities (such as on REV Through Bore)
+     *
+     * @return raw velocity
+     */
     public double getRawVelocity() {
         int multiplier = getMultiplier();
         return motor.getVelocity() * multiplier;
     }
 
+    /**
+     * Uses velocity estimates gathered in {@link #getCurrentPosition} to estimate the upper bits of velocity
+     * that are lost in overflow due to velocity being transmitted as 16 bits.
+     * CAVEAT: must regularly call {@link #getCurrentPosition} for the compensation to work correctly.
+     *
+     * @return corrected velocity
+     */
     public double getCorrectedVelocity() {
-        return inverseOverflow(getRawVelocity(), velocityEstimate);
+        double median = velocityEstimates[0] > velocityEstimates[1]
+                ? Math.max(velocityEstimates[1], Math.min(velocityEstimates[0], velocityEstimates[2]))
+                : Math.max(velocityEstimates[0], Math.min(velocityEstimates[1], velocityEstimates[2]));
+        return inverseOverflow(getRawVelocity(), median);
     }
 }


### PR DESCRIPTION
Sometimes, due to noisy timing data, the numerical derivative used in this method has enough error to reach the wrong "step" and spike the compensated velocity measurement. The `AveragingRingBuffer` util smooths the numerical derivative and eliminates this problem.

Edit: The `AveragingRingBuffer` util has been removed and replaced with the SDK's `MovingStatistics`.

Edit 2: The latest implementation uses a 5x more robust `inverseOverflow` method and a 3 sample median filter on the numerical velocity estimate.