### PR TITLE
Max Angular Velo Tuner

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
@@ -66,8 +66,8 @@ public class DriveConstants {
      */
     public static double MAX_VEL = 30;
     public static double MAX_ACCEL = 30;
-    public static double MAX_ANG_VEL = Math.toRadians(120);
-    public static double MAX_ANG_ACCEL = Math.toRadians(120);
+    public static double MAX_ANG_VEL = Math.toRadians(60);
+    public static double MAX_ANG_ACCEL = Math.toRadians(60);
 
 
     public static double encoderTicksToInches(double ticks) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/DriveConstants.java
@@ -66,8 +66,8 @@ public class DriveConstants {
      */
     public static double MAX_VEL = 30;
     public static double MAX_ACCEL = 30;
-    public static double MAX_ANG_VEL = Math.toRadians(180);
-    public static double MAX_ANG_ACCEL = Math.toRadians(180);
+    public static double MAX_ANG_VEL = Math.toRadians(120);
+    public static double MAX_ANG_ACCEL = Math.toRadians(120);
 
 
     public static double encoderTicksToInches(double ticks) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -243,11 +243,11 @@ public class SampleMecanumDrive extends MecanumDrive {
 
         packet.put("x", currentPose.getX());
         packet.put("y", currentPose.getY());
-        packet.put("heading", currentPose.getHeading());
+        packet.put("heading (deg)", Math.toDegrees(currentPose.getHeading()));
 
         packet.put("xError", lastError.getX());
         packet.put("yError", lastError.getY());
-        packet.put("headingError", lastError.getHeading());
+        packet.put("headingError (deg)", Math.toDegrees(lastError.getHeading()));
 
         switch (mode) {
             case IDLE:
@@ -283,7 +283,7 @@ public class SampleMecanumDrive extends MecanumDrive {
                 break;
             }
             case FOLLOW_TRAJECTORY: {
-                setDriveSignal(follower.update(currentPose));
+                setDriveSignal(follower.update(currentPose, getPoseVelocity()));
 
                 Trajectory trajectory = follower.getTrajectory();
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
@@ -231,11 +231,11 @@ public class SampleTankDrive extends TankDrive {
 
         packet.put("x", currentPose.getX());
         packet.put("y", currentPose.getY());
-        packet.put("heading", currentPose.getHeading());
+        packet.put("heading (deg)", Math.toDegrees(currentPose.getHeading()));
 
         packet.put("xError", lastError.getX());
         packet.put("yError", lastError.getY());
-        packet.put("headingError", lastError.getHeading());
+        packet.put("headingError (deg)", Math.toDegrees(lastError.getHeading()));
 
         switch (mode) {
             case IDLE:

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/MaxAngularVeloTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/MaxAngularVeloTuner.java
@@ -1,0 +1,66 @@
+package org.firstinspires.ftc.teamcode.drive.opmode;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.roadrunner.geometry.Pose2d;
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.util.ElapsedTime;
+
+import org.firstinspires.ftc.teamcode.drive.SampleMecanumDrive;
+
+import java.util.Objects;
+
+/**
+ * This routine is designed to calculate the maximum angular velocity your bot can achieve under load.
+ * <p>
+ * Upon pressing start, your bot will turn at max power for RUNTIME seconds.
+ * <p>
+ * Further fine tuning of MAX_ANG_VEL may be desired.
+ */
+
+@Config
+@Autonomous(group = "drive")
+public class MaxAngularVeloTuner extends LinearOpMode {
+    public static double RUNTIME = 4.0;
+
+    private ElapsedTime timer;
+    private double maxAngVelocity = 0.0;
+
+    @Override
+    public void runOpMode() throws InterruptedException {
+        SampleMecanumDrive drive = new SampleMecanumDrive(hardwareMap);
+
+        drive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+
+        telemetry.addLine("Your bot will turn at full speed for " + RUNTIME + " seconds.");
+        telemetry.addLine("Please ensure you have enough space cleared.");
+        telemetry.addLine("");
+        telemetry.addLine("Press start when ready.");
+        telemetry.update();
+
+        waitForStart();
+
+        telemetry.clearAll();
+        telemetry.update();
+
+        drive.setDrivePower(new Pose2d(0, 0, 1));
+        timer = new ElapsedTime();
+
+        while (!isStopRequested() && timer.seconds() < RUNTIME) {
+            drive.updatePoseEstimate();
+
+            Pose2d poseVelo = Objects.requireNonNull(drive.getPoseVelocity(), "poseVelocity() must not be null. Ensure that the getWheelVelocities() method has been overridden in your localizer.");
+
+            maxAngVelocity = Math.max(poseVelo.getHeading(), maxAngVelocity);
+        }
+
+        drive.setDrivePower(new Pose2d());
+
+        telemetry.addData("Max Angular Velocity (rad)", maxAngVelocity);
+        telemetry.addData("Max Angular Velocity (deg)", Math.toDegrees(maxAngVelocity));
+        telemetry.update();
+
+        while (!isStopRequested()) idle();
+    }
+}


### PR DESCRIPTION
- Implements a `MaxAngularVeloTuner` opmode
- Lower default `MAX_ANG_VELO` to 120 deg/s
    - My goBILDA Strafer v1 has a tested maximum angular velocity of a little over 130 deg/s at 12.7 V (battery was a little low but I think it's still representative) and 30lbs of load (including the strafer chassis itself). The Strafer chassises are probably the most widespread chassises in FTC so I think they make decent default values. Although the V1 is discontinued, it is still very popular and I don't think the current V3 version—which is much faster—will be as widespread until next year, considering the fact that the number of registered teams has [dropped 50% this year](https://docs.google.com/spreadsheets/d/1ZaT-Qw1HgUWfzUA944WaSHOvQv0bczVdris-MMXEwi0/edit?usp=sharing).
- Send heading and heading error in degrees in the sample drives
    - Radians aren't super intuitive to think about for most people
- Pass in `getPoseVelocity()` to `follower.update()`
    - Should default to `null` if `getPoseVelocity()` is not overriden in the localizer, keeping previous functionality in place
    - Allows the follower to use the less noisy pose velocities if overriden in the localizer. The PID's in the follower previously did not receive pose velocity thus `kD` acted upon the noisier dx/dt measurements.