### PR TITLE
Clarify that the minimum firmware requirement is imposed by Road Runner, not the SDK

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/LynxModuleUtil.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/LynxModuleUtil.java
@@ -111,7 +111,7 @@ public class LynxModuleUtil {
         if (outdatedModules.size() > 0) {
             StringBuilder msgBuilder = new StringBuilder();
             msgBuilder.append("One or more of the attached Lynx modules has outdated firmware\n");
-            msgBuilder.append(Misc.formatInvariant("Mandatory minimum firmware version: %s\n",
+            msgBuilder.append(Misc.formatInvariant("Mandatory minimum firmware version for Road Runner: %s\n",
                     MIN_VERSION.toString()));
             for (Map.Entry<String, LynxFirmwareVersion> entry : outdatedModules.entrySet()) {
                 msgBuilder.append(Misc.formatInvariant(


### PR DESCRIPTION
REV Robotics has had several customers who think the minimum firmware error is built into the FTC SDK. This PR clarifies that it comes from Road Runner.