### PR TITLE
Make encoder wrapper's direction independent of backing motor's direction

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
@@ -2,6 +2,7 @@ package org.firstinspires.ftc.teamcode.util;
 
 import com.acmerobotics.roadrunner.util.NanoClock;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
 
 /**
  * Wraps a motor instance to provide corrected velocity counts and allow reversing independently of the corresponding
@@ -29,7 +30,7 @@ public class Encoder {
         }
 
         public int getMultiplier() {
-            return multiplier * (motor.getDirection().inverted() ? -1 : 1);
+            return multiplier;
         }
     }
 
@@ -61,6 +62,10 @@ public class Encoder {
         return direction;
     }
 
+    private int getMultiplier() {
+        return getDirection().getMultiplier() * (motor.getDirection() == DcMotorSimple.Direction.FORWARD ? 1 : -1);
+    }
+
     /**
      * Allows you to set the direction of the counts and velocity without modifying the motor's direction state
      * @param direction either reverse or forward depending on if encoder counts should be negated
@@ -70,7 +75,7 @@ public class Encoder {
     }
 
     public int getCurrentPosition() {
-        int multiplier = direction.getMultiplier();
+        int multiplier = getMultiplier();
         int currentPosition = motor.getCurrentPosition() * multiplier;
         if (currentPosition != lastPosition) {
             double currentTime = clock.seconds();
@@ -83,7 +88,7 @@ public class Encoder {
     }
 
     public double getRawVelocity() {
-        int multiplier = direction.getMultiplier();
+        int multiplier = getMultiplier();
         return motor.getVelocity() * multiplier;
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/Encoder.java
@@ -4,7 +4,7 @@ import com.acmerobotics.roadrunner.util.NanoClock;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 
 /**
- * Wraps a motor instance to provide corrected velocity counts and allow reversing without changing the corresponding
+ * Wraps a motor instance to provide corrected velocity counts and allow reversing independently of the corresponding
  * slot's motor direction
  */
 public class Encoder {
@@ -29,7 +29,7 @@ public class Encoder {
         }
 
         public int getMultiplier() {
-            return multiplier;
+            return multiplier * (motor.getDirection().inverted() ? -1 : 1);
         }
     }
 


### PR DESCRIPTION
Currently, one can set an `Encoder`'s direction without affecting the backing `DcMotorEx`'s direction; however, if one sets the direction of the backing `DcMotorEx`, the `Encoder`'s direction will change. If one for example uses the encoder slots of intake motors which they reverse to outake, the `Encoder`'s direction will swap with the motor, wreaking havoc to localization. This patch prevents that by making `Encoder` direction completely independent of `DcMotorEx` direction by reversing the `Encoder` direction if the `DcMotorEx` direction is reversed.

**Note: this is a breaking change; if one uses an already reversed motor to back their `Encoder` the direction of the `Encoder` will reverse.**