### PR TITLE
Fix wait and turn trajectory sequence marker bug

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/trajectorysequence/TrajectorySequenceBuilder.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/trajectorysequence/TrajectorySequenceBuilder.java
@@ -580,12 +580,16 @@ public class TrajectorySequenceBuilder {
 
             if (segment instanceof WaitSegment) {
                 List<TrajectoryMarker> newMarkers = new ArrayList<>(segment.getMarkers());
+
+                newMarkers.addAll(sequenceSegments.get(segmentIndex).getMarkers());
                 newMarkers.add(new TrajectoryMarker(segmentOffsetTime, marker.getCallback()));
 
                 WaitSegment thisSegment = (WaitSegment) segment;
                 newSegment = new WaitSegment(thisSegment.getStartPose(), thisSegment.getDuration(), newMarkers);
             } else if (segment instanceof TurnSegment) {
                 List<TrajectoryMarker> newMarkers = new ArrayList<>(segment.getMarkers());
+
+                newMarkers.addAll(sequenceSegments.get(segmentIndex).getMarkers());
                 newMarkers.add(new TrajectoryMarker(segmentOffsetTime, marker.getCallback()));
 
                 TurnSegment thisSegment = (TurnSegment) segment;


### PR DESCRIPTION
The wait and turn segments in `TrajectorySequence` would only support a single marker, the last one that was projected onto it.
This is because the markers in that segment were overwritten during projection.
`TrajectorySegment` handled this correctly. `TurnSegment` and `WaitSegment` did not.

Cause of the bug was just an immutability/mutability mess in the projection logic. Apologies.