### PR TITLE
Rework the IMU axes remapping

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -94,9 +94,27 @@ public class SampleMecanumDrive extends MecanumDrive {
         parameters.angleUnit = BNO055IMU.AngleUnit.RADIANS;
         imu.initialize(parameters);
 
-        // TODO: if your hub is mounted vertically, remap the IMU axes so that the z-axis points
-        // upward (normal to the floor) using a command like the following:
-        // BNO055IMUUtil.remapAxes(imu, AxesOrder.XYZ, AxesSigns.NPN);
+        // TODO: If the hub containing the IMU you are using is mounted so that the "REV" logo does
+        // not face up, remap the IMU axes so that the z-axis points upward (normal to the floor.)
+        //
+        //             | +Z axis
+        //             |
+        //             |
+        //             |
+        //      _______|_____________     +Y axis
+        //     /       |_____________/|__________
+        //    /   REV / EXPANSION   //
+        //   /       / HUB         //
+        //  /_______/_____________//
+        // |_______/_____________|/
+        //        /
+        //       / +X axis
+        //
+        // This diagram is derived from the axes in section 3.4 https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bno055-ds000.pdf
+        // and the placement of the dot/orientation from https://docs.revrobotics.com/rev-control-system/control-system-overview/dimensions#imu-location
+        //
+        // For example, if +Y in this diagram faces downwards, you would use AxisDirection.NEG_Y.
+        // BNO055IMUUtil.remapZAxis(imu, AxisDirection.NEG_Y);
 
         leftFront = hardwareMap.get(DcMotorEx.class, "leftFront");
         leftRear = hardwareMap.get(DcMotorEx.class, "leftRear");
@@ -280,25 +298,7 @@ public class SampleMecanumDrive extends MecanumDrive {
 
     @Override
     public Double getExternalHeadingVelocity() {
-        // TODO: This must be changed to match your configuration
-        //                           | Z axis
-        //                           |
-        //     (Motor Port Side)     |   / X axis
-        //                       ____|__/____
-        //          Y axis     / *   | /    /|   (IO Side)
-        //          _________ /______|/    //      I2C
-        //                   /___________ //     Digital
-        //                  |____________|/      Analog
-        //
-        //                 (Servo Port Side)
-        //
-        // The positive x axis points toward the USB port(s)
-        //
-        // Adjust the axis rotation rate as necessary
-        // Rotate about the z axis is the default assuming your REV Hub/Control Hub is laying
-        // flat on a surface
-
-        // To work around an SDK bug, use -zRotationRate in place of xRotationRate 
+        // To work around an SDK bug, use -zRotationRate in place of xRotationRate
         // and -xRotationRate in place of zRotationRate (yRotationRate behaves as 
         // expected). This bug does NOT affect orientation. 
         //

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
@@ -90,9 +90,27 @@ public class SampleTankDrive extends TankDrive {
         parameters.angleUnit = BNO055IMU.AngleUnit.RADIANS;
         imu.initialize(parameters);
 
-        // TODO: if your hub is mounted vertically, remap the IMU axes so that the z-axis points
-        // upward (normal to the floor) using a command like the following:
-        // BNO055IMUUtil.remapAxes(imu, AxesOrder.XYZ, AxesSigns.NPN);
+        // TODO: If the hub containing the IMU you are using is mounted so that the "REV" logo does
+        // not face up, remap the IMU axes so that the z-axis points upward (normal to the floor.)
+        //
+        //             | +Z axis
+        //             |
+        //             |
+        //             |
+        //      _______|_____________     +Y axis
+        //     /       |_____________/|__________
+        //    /   REV / EXPANSION   //
+        //   /       / HUB         //
+        //  /_______/_____________//
+        // |_______/_____________|/
+        //        /
+        //       / +X axis
+        //
+        // This diagram is derived from the axes in section 3.4 https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bno055-ds000.pdf
+        // and the placement of the dot/orientation from https://docs.revrobotics.com/rev-control-system/control-system-overview/dimensions#imu-location
+        //
+        // For example, if +Y in this diagram faces downwards, you would use AxisDirection.NEG_Y.
+        // BNO055IMUUtil.remapZAxis(imu, AxisDirection.NEG_Y);
 
         // add/remove motors depending on your robot (e.g., 6WD)
         DcMotorEx leftFront = hardwareMap.get(DcMotorEx.class, "leftFront");
@@ -284,24 +302,6 @@ public class SampleTankDrive extends TankDrive {
 
     @Override
     public Double getExternalHeadingVelocity() {
-        // TODO: This must be changed to match your configuration
-        //                           | Z axis
-        //                           |
-        //     (Motor Port Side)     |   / X axis
-        //                       ____|__/____
-        //          Y axis     / *   | /    /|   (IO Side)
-        //          _________ /______|/    //      I2C
-        //                   /___________ //     Digital
-        //                  |____________|/      Analog
-        //
-        //                 (Servo Port Side)
-        //
-        // The positive x axis points toward the USB port(s)
-        //
-        // Adjust the axis rotation rate as necessary
-        // Rotate about the z axis is the default assuming your REV Hub/Control Hub is laying
-        // flat on a surface
-
         // To work around an SDK bug, use -zRotationRate in place of xRotationRate
         // and -xRotationRate in place of zRotationRate (yRotationRate behaves as
         // expected). This bug does NOT affect orientation.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/AxesSigns.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/AxesSigns.java
@@ -18,4 +18,28 @@ public enum AxesSigns {
     AxesSigns(int bVal) {
         this.bVal = bVal;
     }
+
+    public static AxesSigns fromBinaryValue(int bVal) {
+        int maskedVal = bVal & 0x07;
+        switch (maskedVal) {
+            case 0b000:
+                return AxesSigns.PPP;
+            case 0b001:
+                return AxesSigns.PPN;
+            case 0b010:
+                return AxesSigns.PNP;
+            case 0b011:
+                return AxesSigns.PNN;
+            case 0b100:
+                return AxesSigns.NPP;
+            case 0b101:
+                return AxesSigns.NPN;
+            case 0b110:
+                return AxesSigns.NNP;
+            case 0b111:
+                return AxesSigns.NNN;
+            default:
+                throw new IllegalStateException("Unexpected value for maskedVal: " + maskedVal);
+        }
+    }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/AxisDirection.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/AxisDirection.java
@@ -1,0 +1,8 @@
+package org.firstinspires.ftc.teamcode.util;
+
+/**
+ * A direction for an axis to be remapped to
+ */
+public enum AxisDirection {
+    POS_X, NEG_X, POS_Y, NEG_Y, POS_Z, NEG_Z
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/BNO055IMUUtil.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/BNO055IMUUtil.java
@@ -9,27 +9,54 @@ import org.firstinspires.ftc.robotcore.external.navigation.AxesOrder;
  */
 public class BNO055IMUUtil {
     /**
-     * Remap BNO055 IMU axes and signs. For reference, the default order is {@link AxesOrder#ZYX}.
+     * Error for attempting an illegal remapping (lhs or multiple same axes)
+     */
+    public static class InvalidAxisRemapException extends RuntimeException {
+        public InvalidAxisRemapException(String detailMessage) {
+            super(detailMessage);
+        }
+    }
+
+    /**
+     * Remap BNO055 IMU axes and signs. For reference, the default order is {@link AxesOrder#XYZ}.
      * Call after {@link BNO055IMU#initialize(BNO055IMU.Parameters)}. Although this isn't
      * mentioned in the datasheet, the axes order appears to affect the onboard sensor fusion.
      *
-     * Adapted from <a href="https://ftcforum.usfirst.org/forum/ftc-technology/53812-mounting-the-revhub-vertically?p=56587#post56587">this post</a>.
+     * Adapted from <a href="https://ftcforum.firstinspires.org/forum/ftc-technology/53812-mounting-the-revhub-vertically?p=56587#post56587">this post</a>.
+     * Reference the <a href="https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bno055-ds000.pdf">BNO055 Datasheet</a> for details.
+     *
+     * NOTE: Remapping axes can be somewhat confusing. Instead, use {@link #remapZAxis}, if appropriate.
      *
      * @param imu IMU
      * @param order axes order
      * @param signs axes signs
      */
-    public static void remapAxes(BNO055IMU imu, AxesOrder order, AxesSigns signs) {
+    public static void swapThenFlipAxes(BNO055IMU imu, AxesOrder order, AxesSigns signs) {
         try {
-            // the indices correspond with the 2-bit encodings specified in the datasheet
+            // the indices correspond with the 2-bit axis encodings specified in the datasheet
             int[] indices = order.indices();
-            int axisMapConfig = 0;
-            axisMapConfig |= (indices[0] << 4);
-            axisMapConfig |= (indices[1] << 2);
-            axisMapConfig |= (indices[2] << 0);
+            // AxesSign's values align with the datasheet
+            int axisMapSigns = signs.bVal;
 
-            // the BNO055 driver flips the first orientation vector so we also flip here
-            int axisMapSign = signs.bVal ^ (0b100 >> indices[0]);
+            if (indices[0] == indices[1] || indices[0] == indices[2] || indices[1] == indices[2]) {
+                throw new InvalidAxisRemapException("Same axis cannot be included in AxesOrder twice");
+            }
+
+            // ensure right-handed coordinate system
+            boolean isXSwapped = indices[0] != 0;
+            boolean isYSwapped = indices[1] != 1;
+            boolean isZSwapped = indices[2] != 2;
+            boolean areTwoAxesSwapped = (isXSwapped || isYSwapped || isZSwapped)
+                    && (!isXSwapped || !isYSwapped || !isZSwapped);
+            boolean oddNumOfFlips = (((axisMapSigns >> 2) ^ (axisMapSigns >> 1) ^ axisMapSigns) & 1) == 1;
+            // != functions as xor
+            if (areTwoAxesSwapped != oddNumOfFlips) {
+                throw new InvalidAxisRemapException("Coordinate system is left-handed");
+            }
+
+            // Bit:  7  6 |  5  4  |  3  2  |  1  0  |
+            //   reserved | z axis | y axis | x axis |
+            int axisMapConfig = indices[2] << 4 | indices[1] << 2 | indices[0];
 
             // Enter CONFIG mode
             imu.write8(BNO055IMU.Register.OPR_MODE, BNO055IMU.SensorMode.CONFIG.bVal & 0x0F);
@@ -40,7 +67,7 @@ public class BNO055IMUUtil {
             imu.write8(BNO055IMU.Register.AXIS_MAP_CONFIG, axisMapConfig & 0x3F);
 
             // Write the AXIS_MAP_SIGN register
-            imu.write8(BNO055IMU.Register.AXIS_MAP_SIGN, axisMapSign & 0x07);
+            imu.write8(BNO055IMU.Register.AXIS_MAP_SIGN, axisMapSigns & 0x07);
 
             // Switch back to the previous mode
             imu.write8(BNO055IMU.Register.OPR_MODE, imu.getParameters().mode.bVal & 0x0F);
@@ -49,5 +76,53 @@ public class BNO055IMUUtil {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+    }
+
+    /**
+     * Remaps the IMU coordinate system so that the remapped +Z faces the provided
+     * {@link AxisDirection}. See {@link #swapThenFlipAxes} for details about the remapping.
+     *
+     * @param imu IMU
+     * @param direction axis direction
+     */
+    public static void remapZAxis(BNO055IMU imu, AxisDirection direction) {
+        switch (direction) {
+            case POS_X:
+                swapThenFlipAxes(imu, AxesOrder.ZYX, AxesSigns.NPP);
+                break;
+            case NEG_X:
+                swapThenFlipAxes(imu, AxesOrder.ZYX, AxesSigns.PPN);
+                break;
+            case POS_Y:
+                swapThenFlipAxes(imu, AxesOrder.XZY, AxesSigns.PNP);
+                break;
+            case NEG_Y:
+                swapThenFlipAxes(imu, AxesOrder.XZY, AxesSigns.PPN);
+                break;
+            case POS_Z:
+                swapThenFlipAxes(imu, AxesOrder.XYZ, AxesSigns.PPP);
+                break;
+            case NEG_Z:
+                swapThenFlipAxes(imu, AxesOrder.XYZ, AxesSigns.PNN);
+                break;
+        }
+    }
+
+    /**
+     * Now deprecated due to unintuitive parameter order.
+     * Use {@link #swapThenFlipAxes} or {@link #remapZAxis} instead.
+     *
+     * @param imu IMU
+     * @param order axes order
+     * @param signs axes signs
+     */
+    @Deprecated
+    public static void remapAxes(BNO055IMU imu, AxesOrder order, AxesSigns signs) {
+        AxesOrder adjustedAxesOrder = order.reverse();
+        int[] indices = order.indices();
+        int axisSignValue = signs.bVal ^ (0b100 >> indices[0]);
+        AxesSigns adjustedAxesSigns = AxesSigns.fromBinaryValue(axisSignValue);
+
+        swapThenFlipAxes(imu, adjustedAxesOrder, adjustedAxesSigns);
     }
 }


### PR DESCRIPTION
This system deprecates the unintuitive `remapAxes` method and replaces it with `remapAxesIntuitive`. Additionally, it provides the `remapZAxis` method that should be sufficient for just accessing the heading. This is currently untested and I'm just looking for initial feedback for now.