### PR TITLE
Correct the IMU angular velocity axes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -298,7 +298,20 @@ public class SampleMecanumDrive extends MecanumDrive {
         // Rotate about the z axis is the default assuming your REV Hub/Control Hub is laying
         // flat on a surface
 
-        return (double) imu.getAngularVelocity().zRotationRate;
+        /*TODO: IMPORTANT!
+        If you are using the X axis from the above diagram,
+        ensure that you use the negative Z axis for angular velocity ONLY.
+        Likewise, if you are using the Z axis from above, ensure that you use the
+        negative X axis for angular velocity ONLY (this does NOT affect orientation).
+
+        //For angular velocity around the X axis:
+        return (double) -imu.getAngularVelocity().zRotationRate;
+
+        The Y axis is not affected.
+         */
+
+        //See comment above, following is for angular velocity around the Z axis
+        return (double) -imu.getAngularVelocity().xRotationRate;
     }
 
     public static TrajectoryVelocityConstraint getVelocityConstraint(double maxVel, double maxAngularVel, double trackWidth) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleMecanumDrive.java
@@ -298,19 +298,11 @@ public class SampleMecanumDrive extends MecanumDrive {
         // Rotate about the z axis is the default assuming your REV Hub/Control Hub is laying
         // flat on a surface
 
-        /*TODO: IMPORTANT!
-        If you are using the X axis from the above diagram,
-        ensure that you use the negative Z axis for angular velocity ONLY.
-        Likewise, if you are using the Z axis from above, ensure that you use the
-        negative X axis for angular velocity ONLY (this does NOT affect orientation).
-
-        //For angular velocity around the X axis:
-        return (double) -imu.getAngularVelocity().zRotationRate;
-
-        The Y axis is not affected.
-         */
-
-        //See comment above, following is for angular velocity around the Z axis
+        // To work around an SDK bug, use -zRotationRate in place of xRotationRate 
+        // and -xRotationRate in place of zRotationRate (yRotationRate behaves as 
+        // expected). This bug does NOT affect orientation. 
+        //
+        // See https://github.com/FIRST-Tech-Challenge/FtcRobotController/issues/251 for details.
         return (double) -imu.getAngularVelocity().xRotationRate;
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
@@ -302,7 +302,20 @@ public class SampleTankDrive extends TankDrive {
         // Rotate about the z axis is the default assuming your REV Hub/Control Hub is laying
         // flat on a surface
 
-        return (double) imu.getAngularVelocity().zRotationRate;
+        /*TODO: IMPORTANT!
+        If you are using the X axis from the above diagram,
+        ensure that you use the negative Z axis for angular velocity ONLY.
+        Likewise, if you are using the Z axis from above, ensure that you use the
+        negative X axis for angular velocity ONLY (this does NOT affect orientation).
+
+        //For angular velocity around the X axis:
+        return (double) -imu.getAngularVelocity().zRotationRate;
+
+        The Y axis is not affected.
+         */
+
+        //See comment above, following is for angular velocity around the Z axis
+        return (double) -imu.getAngularVelocity().xRotationRate;
     }
 
     public static TrajectoryVelocityConstraint getVelocityConstraint(double maxVel, double maxAngularVel, double trackWidth) {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/SampleTankDrive.java
@@ -302,19 +302,11 @@ public class SampleTankDrive extends TankDrive {
         // Rotate about the z axis is the default assuming your REV Hub/Control Hub is laying
         // flat on a surface
 
-        /*TODO: IMPORTANT!
-        If you are using the X axis from the above diagram,
-        ensure that you use the negative Z axis for angular velocity ONLY.
-        Likewise, if you are using the Z axis from above, ensure that you use the
-        negative X axis for angular velocity ONLY (this does NOT affect orientation).
-
-        //For angular velocity around the X axis:
-        return (double) -imu.getAngularVelocity().zRotationRate;
-
-        The Y axis is not affected.
-         */
-
-        //See comment above, following is for angular velocity around the Z axis
+        // To work around an SDK bug, use -zRotationRate in place of xRotationRate
+        // and -xRotationRate in place of zRotationRate (yRotationRate behaves as
+        // expected). This bug does NOT affect orientation.
+        //
+        // See https://github.com/FIRST-Tech-Challenge/FtcRobotController/issues/251 for details.
         return (double) -imu.getAngularVelocity().xRotationRate;
     }
 


### PR DESCRIPTION
See SDK issue here: https://github.com/FIRST-Tech-Challenge/FtcRobotController/issues/251 

In essence, as of SDK <v7.0, the X and Z axes from `getAngularVelocity()` in the BNO055IMU class are flipped. This has affected users who use these two axes when running the MaxAngVeloTuner for the last few months, where the maximum angular velocity is reported to be very low, in the 0-5 degree range. The general advice in places like the FTC Discord since the issues were first noticed with this tuner was to use an approximate value for the maximum angular velocity and acceleration such as `toRadians(180);`.

Recently, with the increase in people using the LearnRoadRunner guide (which instructs to use the MaxAngVeloTuner), many people have used the incorrect values, and experience issues when their track width tuning does not work due to it. Last week, I started trying to figure out the cause of these problems, and my search eventually led to the main SDK issue that I linked above. This fix would be a temporary one until a larger main SDK version comes out which fixes it, but as there is no known time estimate for that, it might be good to go ahead and act on it.

My fix includes a comment on the `getExternalHeadingVelocity()` function describing the changes and changes the default Z axis to the inverse X axis (the inverse is necessary because the BNO055IMU inverses the X axis since it expects it to be the Z axis).

I can realize that such a change may not be desirable when it will break upon the next SDK release, so if it is wanted I can edit the PR to instead just include an instructional comment about the necessary changes to the angular velocity axis when using an SDK version <7.0.

Hope this is helpful.