### PR TITLE
Kalman Filter for improved velocity estimation

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LeastSquaresKalmanFilter.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LeastSquaresKalmanFilter.java
@@ -1,0 +1,101 @@
+package org.firstinspires.ftc.teamcode.util.KalmanFilter;
+
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+public class LeastSquaresKalmanFilter {
+
+    protected double Q;
+    protected double R;
+    protected int N;
+    protected double P = 1;
+    protected double K = 0;
+    protected double x;
+    protected SizedStack<Double> estimates;
+    protected LinearRegression regression;
+
+    /**
+     * A kalman filter that uses a least squares regression as it's model.
+     * @param Q Sensor Noise Covariance
+     * @param R Model Covariance
+     * @param N Number of elements we can hold in our stack.
+     */
+    public LeastSquaresKalmanFilter(double Q, double R, int N) {
+        this.Q = Q;
+        this.R = R;
+        this.N = N;
+        this.x = 0;
+        this.estimates = new SizedStack<>(N);
+        initializeStackWith0();
+        regression = new LinearRegression(stackToDoubleArray());
+        solveK();
+    }
+
+    /**
+     * set the state estimate.
+     * @param x state estimate
+     */
+    public void setX(double x) {
+        this.x = x;
+    }
+
+    public double getX() {
+        return x;
+    }
+
+    /**
+     * update the kalman filter for traditional; continous values.
+     * @param measurement the current measurement
+     * @return the optimal state estimate.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public double update(double measurement) {
+        regression.runLeastSquares();
+        x += regression.predictNextValue() - estimates.peek();
+        x += K * (measurement - x);
+        estimates.push(x);
+        regression = new LinearRegression(stackToDoubleArray());
+        return x;
+    }
+
+
+    /**
+     * Iteratively compute K using the D.A.R.E
+     */
+    public void solveK() {
+        for (int i = 0; i < 200; ++i) solveDARE();
+    }
+
+    /**
+     * solve the discrete time algebraic riccati equation (D.A.R.E)
+     */
+    public void solveDARE() {
+        P = P + Q;
+        K = P / (P + R);
+        P = (1-K) * P;
+    }
+
+    /**
+     * initialize the stack to all 0's
+     */
+    protected void initializeStackWith0() {
+        for (int i = 0; i < N; ++i) {
+            estimates.push(0.0);
+        }
+    }
+
+    /**
+     * convert the stack to an array of doubles
+     * @return an array of doubles.
+     */
+    protected double[] stackToDoubleArray() {
+        double[] newValues = new double[N];
+        for (int i = 0; i < estimates.size(); ++i) {
+            newValues[i] = estimates.get(i);
+        }
+        return  newValues;
+    }
+
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LeastSquaresKalmanFilter.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LeastSquaresKalmanFilter.java
@@ -34,18 +34,6 @@ public class LeastSquaresKalmanFilter {
     }
 
     /**
-     * set the state estimate.
-     * @param x state estimate
-     */
-    public void setX(double x) {
-        this.x = x;
-    }
-
-    public double getX() {
-        return x;
-    }
-
-    /**
      * update the kalman filter for traditional; continous values.
      * @param measurement the current measurement
      * @return the optimal state estimate.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LinearRegression.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LinearRegression.java
@@ -42,12 +42,10 @@ public class LinearRegression {
         b = Arrays.stream(y).sum() - m * Arrays.stream(x).sum();
         b /= n;
 
-        System.out.println("in run least squares, n is " + n + " x arr is" + Arrays.toString(x) + " y arr is" + Arrays.toString(y) + "xySum is " + xySum + " m1 is " + m1 + " m2 is " + m2 + " m is " + m + " b is " + b);
     }
 
 
     public double predictNextValue() {
-        System.out.println("in predict value, length is " + x.length + " m is " + m + " and b is " + b);
         return x.length * m + b;
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LinearRegression.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/LinearRegression.java
@@ -1,0 +1,59 @@
+package org.firstinspires.ftc.teamcode.util.KalmanFilter;
+
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.util.Arrays;
+
+public class LinearRegression {
+
+    public double[] x;
+    public double[] y;
+    private double m;
+    private double b;
+
+
+    public LinearRegression(double [] y) {
+        this.y = y;
+        x = new double[y.length];
+        for (int i = 0; i < x.length; ++i) {
+            x[i] = i;
+        }
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void runLeastSquares() {
+        double n = x.length;
+        double xySum = 0;
+        for (int i = 0; i < x.length; ++i) {
+            xySum += x[i] * y[i];
+        }
+        double m1 = n * xySum - Arrays.stream(x).sum() * Arrays.stream(y).sum();
+        double x_squaredSum = 0;
+        for (double v : x) {
+            x_squaredSum += Math.pow(v, 2);
+        }
+        double m2 = n * x_squaredSum - Math.pow(Arrays.stream(x).sum(),2);
+
+        m = m1/m2;
+
+        b = Arrays.stream(y).sum() - m * Arrays.stream(x).sum();
+        b /= n;
+
+        System.out.println("in run least squares, n is " + n + " x arr is" + Arrays.toString(x) + " y arr is" + Arrays.toString(y) + "xySum is " + xySum + " m1 is " + m1 + " m2 is " + m2 + " m is " + m + " b is " + b);
+    }
+
+
+    public double predictNextValue() {
+        System.out.println("in predict value, length is " + x.length + " m is " + m + " and b is " + b);
+        return x.length * m + b;
+    }
+
+
+
+
+
+
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/SizedStack.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/util/KalmanFilter/SizedStack.java
@@ -1,0 +1,26 @@
+package org.firstinspires.ftc.teamcode.util.KalmanFilter;
+
+import java.util.Stack;
+
+/**
+ * from https://stackoverflow.com/questions/7727919/creating-a-fixed-size-stack
+ * @param <T> Type that the stack will hold.
+ */
+public class SizedStack<T> extends Stack<T> {
+	private int maxSize;
+
+	public SizedStack(int size) {
+		super();
+		this.maxSize = size;
+	}
+
+	@Override
+	public T push(T object) {
+		while (this.size() >= maxSize) {
+			this.remove(0);
+		}
+		return super.push(object);
+	}
+
+
+}


### PR DESCRIPTION
Gives users the **option** to estimate the velocity from the encoders using a Kalman Filter. The previous methods remain.

The Kalman Filter in question uses a Linear Regression of the previous N Kalman Filter estimates to act as a model and then corrects this estimate using the new estimated value from the encoder. 
<img width="400" alt="Kalman filter vs inbuilt encoder" src="https://user-images.githubusercontent.com/19732253/147399367-38aecfef-3144-419f-a694-286e9f7829cd.png">
In the image above, the red line shows the inbuilt velocity estimation method, and the blue line shows these values passed into the previously mentioned Kalman Filter.

An important note is that the Kalman Filter generally introduces significantly less phase lag into the signal than alternative smoothing algorithms such as low pass filters or moving averages.

