### PR TITLE
Remove nonexistent AccelLogger from TuningOpModes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/TuningOpModes.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/TuningOpModes.java
@@ -25,7 +25,6 @@ public final class TuningOpModes {
         if (DISABLED) return;
 
         List<Class<? extends OpMode>> opModes = Arrays.asList(
-                AccelLogger.class,
                 AngularRampLogger.class,
                 ForwardPushTest.class,
                 ForwardRampLogger.class,


### PR DESCRIPTION
This would cause builds to fail as the class does not exist.

Before issuing a pull request, please see the contributing page.
