### PR TITLE
Make Data fields in Logger OpModes public

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/AngularRampLogger.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/AngularRampLogger.java
@@ -20,29 +20,29 @@ public final class AngularRampLogger extends LinearOpMode {
         DriveView view = new DriveView(hardwareMap);
 
         class Data {
-            final String type = view.type;
+            public final String type = view.type;
 
-            final List<List<Double>> leftPowerTimes = new ArrayList<>();
-            final List<List<Double>> leftPowers = new ArrayList<>();
+            public final List<List<Double>> leftPowerTimes = new ArrayList<>();
+            public final List<List<Double>> leftPowers = new ArrayList<>();
 
-            final List<List<Double>> rightPowerTimes = new ArrayList<>();
-            final List<List<Double>> rightPowers = new ArrayList<>();
+            public final List<List<Double>> rightPowerTimes = new ArrayList<>();
+            public final List<List<Double>> rightPowers = new ArrayList<>();
 
-            final List<Double> voltageTimes = new ArrayList<>();
-            final List<Double> voltages = new ArrayList<>();
+            public final List<Double> voltageTimes = new ArrayList<>();
+            public final List<Double> voltages = new ArrayList<>();
 
-            final List<Double> encTimes = new ArrayList<>();
-            final List<List<Integer>> leftEncPositions = new ArrayList<>();
-            final List<List<Integer>> leftEncVels = new ArrayList<>();
-            final List<List<Integer>> rightEncPositions = new ArrayList<>();
-            final List<List<Integer>> rightEncVels = new ArrayList<>();
-            final List<List<Integer>> parEncPositions = new ArrayList<>();
-            final List<List<Integer>> parEncVels = new ArrayList<>();
-            final List<List<Integer>> perpEncPositions = new ArrayList<>();
-            final List<List<Integer>> perpEncVels = new ArrayList<>();
+            public final List<Double> encTimes = new ArrayList<>();
+            public final List<List<Integer>> leftEncPositions = new ArrayList<>();
+            public final List<List<Integer>> leftEncVels = new ArrayList<>();
+            public final List<List<Integer>> rightEncPositions = new ArrayList<>();
+            public final List<List<Integer>> rightEncVels = new ArrayList<>();
+            public final List<List<Integer>> parEncPositions = new ArrayList<>();
+            public final List<List<Integer>> parEncVels = new ArrayList<>();
+            public final List<List<Integer>> perpEncPositions = new ArrayList<>();
+            public final List<List<Integer>> perpEncVels = new ArrayList<>();
 
-            final List<Double> angVelTimes = new ArrayList<>();
-            final List<List<Double>> angVels = new ArrayList<>();
+            public final List<Double> angVelTimes = new ArrayList<>();
+            public final List<List<Double>> angVels = new ArrayList<>();
         }
 
         Data data = new Data();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/ForwardRampLogger.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/ForwardRampLogger.java
@@ -19,17 +19,17 @@ public final class ForwardRampLogger extends LinearOpMode {
         DriveView view = new DriveView(hardwareMap);
 
         class Data {
-            final String type = view.type;
+            public final String type = view.type;
 
-            final List<List<Double>> powerTimes = new ArrayList<>();
-            final List<List<Double>> powers = new ArrayList<>();
+            public final List<List<Double>> powerTimes = new ArrayList<>();
+            public final List<List<Double>> powers = new ArrayList<>();
 
-            final List<Double> voltageTimes = new ArrayList<>();
-            final List<Double> voltages = new ArrayList<>();
+            public final List<Double> voltageTimes = new ArrayList<>();
+            public final List<Double> voltages = new ArrayList<>();
 
-            final List<Double> encTimes = new ArrayList<>();
-            final List<List<Integer>> forwardEncPositions = new ArrayList<>();
-            final List<List<Integer>> forwardEncVels = new ArrayList<>();
+            public final List<Double> encTimes = new ArrayList<>();
+            public final List<List<Integer>> forwardEncPositions = new ArrayList<>();
+            public final List<List<Integer>> forwardEncVels = new ArrayList<>();
         }
 
         Data data = new Data();


### PR DESCRIPTION
With the fields package-private, at the end of the Logger OpMode execution, 
`
Error: Unable to write data to /storage/emulated/0/RoadRunner/tuning/angular-ramp/1667346524863.json: RuntimeException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.firstinspires.ftc.teamcode.tuning.AngularRampLogger$1Data and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
`

occurs as Jackson only serializes public fields.