### PR TITLE
Added recommended max velocity to reduce confusion

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/MaxVelocityTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/drive/opmode/MaxVelocityTuner.java
@@ -69,7 +69,8 @@ public class MaxVelocityTuner extends LinearOpMode {
 
         double effectiveKf = DriveConstants.getMotorVelocityF(veloInchesToTicks(maxVelocity));
 
-        telemetry.addData("Max Velocity", maxVelocity);
+        telemetry.addData("Theoretical Max Velocity", maxVelocity);
+        telemetry.addData("Recommended Max Velocity", maxVelocity * .8);
         telemetry.addData("Voltage Compensated kF", effectiveKf * batteryVoltageSensor.getVoltage() / 12);
         telemetry.update();
 


### PR DESCRIPTION
I've seen teams have trouble with Max Velocity, thinking that they should use that number, so I changed the telemetry readings to Theoretical Max Velocity (same as the regular max velocity reading) and Recommended Max Velocity (80% of the theoretical max velocity).