### PR TITLE
Require odometry wheel positions to run ManualFeedbackTuner

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/ManualFeedbackTuner.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/tuning/ManualFeedbackTuner.java
@@ -14,7 +14,16 @@ public final class ManualFeedbackTuner extends LinearOpMode {
     public void runOpMode() throws InterruptedException {
         if (TuningOpModes.DRIVE_CLASS.equals(MecanumDrive.class)) {
             MecanumDrive drive = new MecanumDrive(hardwareMap, new Pose2d(0, 0, 0));
-
+            
+            if (drive.localizer instanceof TwoDeadWheelLocalizer) {
+                if (TwoDeadWheelLocalizer.PARAMS.perpXTicks == 0 && TwoDeadWheelLocalizer.PARAMS.parYTicks == 0) {
+                    throw new AssertionError("Odometry wheel locations not set! Run AngularRampLogger to tune them.");
+                }
+            } else if (drive.localizer instanceof ThreeDeadWheelLocalizer) {
+                if (ThreeDeadWheelLocalizer.PARAMS.perpXTicks == 0 && ThreeDeadWheelLocalizer.PARAMS.par0YTicks == 0 && ThreeDeadWheelLocalizer.PARAMS.par1YTicks == 1) {
+                    throw new AssertionError("Odometry wheel locations not set! Run AngularRampLogger to tune them.");
+                }
+            }
             waitForStart();
 
             while (opModeIsActive()) {
@@ -27,6 +36,15 @@ public final class ManualFeedbackTuner extends LinearOpMode {
         } else if (TuningOpModes.DRIVE_CLASS.equals(TankDrive.class)) {
             TankDrive drive = new TankDrive(hardwareMap, new Pose2d(0, 0, 0));
 
+            if (drive.localizer instanceof TwoDeadWheelLocalizer) {
+                if (TwoDeadWheelLocalizer.PARAMS.perpXTicks == 0 && TwoDeadWheelLocalizer.PARAMS.parYTicks == 0) {
+                    throw new AssertionError("Odometry wheel locations not set! Run AngularRampLogger to tune them.");
+                }
+            } else if (drive.localizer instanceof ThreeDeadWheelLocalizer) {
+                if (ThreeDeadWheelLocalizer.PARAMS.perpXTicks == 0 && ThreeDeadWheelLocalizer.PARAMS.par0YTicks == 0 && ThreeDeadWheelLocalizer.PARAMS.par1YTicks == 1) {
+                    throw new AssertionError("Odometry wheel locations not set! Run AngularRampLogger to tune them.");
+                }
+            }
             waitForStart();
 
             while (opModeIsActive()) {


### PR DESCRIPTION
Before issuing a pull request, please see the contributing page.
[Many](https://github.com/acmerobotics/road-runner-quickstart/issues/291) [teams](https://github.com/acmerobotics/road-runner-quickstart/issues/270) seem to run ManualFeedbackTuner without setting odometry wheel positions, causing shaking of the robot and many confused questions in the FTC Discord. 

I believe that this pull request solves this as suggested [here](https://github.com/acmerobotics/road-runner-quickstart/issues/270#issuecomment-1784524754v). However, not sure whether this is the right way to go about this or if the error should be more detailed. Any suggestions welcome.