### PR TITLE
fix otos units

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OTOSLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OTOSLocalizer.java
@@ -26,6 +26,8 @@ public class OTOSLocalizer implements Localizer {
         otos = hardwareMap.get(SparkFunOTOS.class, "sensor_otos");
         currentPose = initialPose;
         otos.setPosition(OTOSKt.toOTOSPose(currentPose));
+        otos.setLinearUnit(DistanceUnit.INCH);
+        otos.setAngularUnit(AngleUnit.RADIANS);
 
         otos.calibrateImu();
         otos.setLinearScalar(PARAMS.linearScalar);


### PR DESCRIPTION
apparently I forgot to set the angular unit to radians in the otos localizer; since this otos object is the same one used by tuning opmodes we don’t have to set the units again

(Inches are the default linear unit but just to be safe)