### PR TITLE
fix PinpointLocalizer initialization because of issues in the driver

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/PinpointLocalizer.java
@@ -33,8 +33,9 @@ public final class PinpointLocalizer implements Localizer {
         //   see https://ftc-docs.firstinspires.org/en/latest/hardware_and_software_configuration/configuring/index.html
         driver = hardwareMap.get(GoBildaPinpointDriver.class, "pinpoint");
 
-        driver.setEncoderResolution(1 / inPerTick, DistanceUnit.INCH);
-        driver.setOffsets(inPerTick * PARAMS.parYTicks, inPerTick * PARAMS.perpXTicks, DistanceUnit.INCH);
+        double mmPerTick = inPerTick * 25.4;
+        driver.setEncoderResolution(1 / mmPerTick, DistanceUnit.MM);
+        driver.setOffsets(mmPerTick * PARAMS.parYTicks, mmPerTick * PARAMS.perpXTicks, DistanceUnit.MM);
 
         // TODO: reverse encoder directions if needed
         initialParDirection = GoBildaPinpointDriver.EncoderDirection.FORWARD;


### PR DESCRIPTION
so I discovered that #508 is caused by an issue in the driver: `setEncoderResolution` accepts a value in ticks / distanceUnit and then attempts to convert that number to mm using the provided unit object, which expects the distance to be in the numerator and not the denominator. Because the default is millimeters, I reverted the localizer constructor to use `mmPerTick` instead so the distanceUnit conversion doesn't affect the value.