### PR TITLE
OTOSLocalizer initialization sequence

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OTOSLocalizer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OTOSLocalizer.java
@@ -31,15 +31,18 @@ public class OTOSLocalizer implements Localizer {
         // TODO: make sure your config has an OTOS device with this name
         //   see https://ftc-docs.firstinspires.org/en/latest/hardware_and_software_configuration/configuring/index.html
         otos = hardwareMap.get(SparkFunOTOS.class, "sensor_otos");
-        currentPose = initialPose;
-        otos.setPosition(OTOSKt.toOTOSPose(currentPose));
         otos.setLinearUnit(DistanceUnit.INCH);
         otos.setAngularUnit(AngleUnit.RADIANS);
-
-        otos.calibrateImu();
+        otos.setOffset(PARAMS.offset);
         otos.setLinearScalar(PARAMS.linearScalar);
         otos.setAngularScalar(PARAMS.angularScalar);
-        otos.setOffset(PARAMS.offset);
+        otos.calibrateImu();
+        otos.resetTracking();
+        
+        currentPose = initialPose;
+        otos.setPosition(OTOSKt.toOTOSPose(currentPose));        
+        
+        
     }
 
     @Override


### PR DESCRIPTION
OTOSLocalizer initialization is in the incorrect sequence / order: 

first set offset and calibrate, then set the initial pose

Before issuing a pull request, please see the contributing page.
